### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,22 @@ yarn add nextjs-basic-auth-middleware
 Set the following configuration option in your `next.config.js`:
 
 ```js
-    experimental: {
-        documentMiddleware: true
+    module.exports = {
+        experimental: {
+            documentMiddleware: true
+        }
     }
 ```
 
 Then add the middleware to the `getInitialProps` method of your document:
 
 ```js
+    import basicAuthMiddleware from 'nextjs-basic-auth-middleware'
+
     Document.getInitialProps = async ({req, res}) => {
-        await basicAuthMiddleware(req, res)
+        await basicAuthMiddleware(req, res, {})
         ...
+        return {}
     }
 ```
 


### PR DESCRIPTION
- improve the README setup chapter

Somehow it is necessary to initialize the `basicAuthMiddleware` with an empty options hash. Otherwise I get an error like `TypeError: Cannot read property 'realm' of undefined` 

Thanks for providing the middleware. Cheerio