### PR TITLE
Remove console.log

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -3,11 +3,10 @@ import { IncomingMessage } from 'http'
 
 export const pathInRequest = (paths: string[], req: IncomingMessage) => {
   if (req.url === undefined) {
-    console.log('is undefined')
+    console.log('request url is undefined')
     return false
   }
 
-  console.log(parse(req.url))
   const path = parse(req.url).pathname
   return paths.some(item => path?.startsWith(item))
 }


### PR DESCRIPTION
It is filling up the server logs with path info. If this is wanted, perhaps put it behind a 'debug' flag ?