### PR TITLE
fix(auth): fix empty credentials returning valid authorization

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -44,20 +44,7 @@ export const parseCredentials = (credentials: string): AuthCredentials => {
 export const compareCredentials = (
   user: auth.BasicAuthResult,
   requiredCredentials: AuthCredentials
-): boolean => {
-  let valid = true
-
-  valid =
-    compare(
-      user.name,
-      requiredCredentials.find(item => item.name === user.name)?.name ?? ''
-    ) && valid
-  valid =
-    compare(
-      user.pass,
-      requiredCredentials.find(item => item.password === user.pass)?.password ??
-        ''
-    ) && valid
-
-  return valid
-}
+): boolean =>
+  requiredCredentials.some(
+    item => compare(user.name, item.name) && compare(user.pass, item.password)
+  )

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -53,5 +53,23 @@ describe('compareCredentials', () => {
         { name: 'test', password: 'test' },
       ])
     ).toBe(false)
+
+    expect(
+      compareCredentials({ name: 'test', pass: '' }, [
+        { name: 'test', password: 'test' },
+      ])
+    ).toBe(false)
+
+    expect(
+      compareCredentials({ name: '', pass: 'test' }, [
+        { name: 'test', password: 'test' },
+      ])
+    ).toBe(false)
+
+    expect(
+      compareCredentials({ name: '', pass: '' }, [
+        { name: 'test', password: 'test' },
+      ])
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
Huge error in the compare code where it was possible to leave credentials out and get authorization. Fixes #4 